### PR TITLE
Add chest object evaluation

### DIFF
--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -625,3 +625,35 @@ func TestIndexAssign(t *testing.T) {
 		}
 	}
 }
+
+func TestChestStatementInstantiationAndAccess(t *testing.T) {
+	input := `
+chest myChest|foo, bar|.
+yar inst be myChest|"fooVal", 5|.
+inst|bar.
+`
+	evaluated := testEval(input)
+	testIntegerObject(t, evaluated, 5)
+}
+
+func TestChestLiteral(t *testing.T) {
+	input := `|foo: 1, bar: 2|`
+	evaluated := testEval(input)
+	chest, ok := evaluated.(*object.Chest)
+	if !ok {
+		t.Fatalf("object not Chest. got=%T", evaluated)
+	}
+	testIntegerObject(t, chest.Items["foo"], 1)
+	testIntegerObject(t, chest.Items["bar"], 2)
+}
+
+func TestChestFieldAssignment(t *testing.T) {
+	input := `
+chest myChest|foo, bar|.
+yar inst be myChest|1, 2|.
+inst|foo be 10.
+inst|foo.
+`
+	evaluated := testEval(input)
+	testIntegerObject(t, evaluated, 10)
+}

--- a/object/object.go
+++ b/object/object.go
@@ -21,6 +21,7 @@ const (
 	ARRAY_OBJ       = "ARRAY"
 	HASHMAP_OBJ     = "HASHMAP"
 	BREAK_OBJ       = "BREAK"
+	CHEST_TYPE_OBJ  = "CHEST_TYPE"
 	CHEST_OBJ       = "CHEST"
 )
 
@@ -178,7 +179,7 @@ type KVP struct {
 }
 
 type HashMap struct {
-	KVPs map[HashKey]KVP
+	MP map[HashKey]KVP
 }
 
 func (h *HashMap) Type() ObjectType { return HASHMAP_OBJ }
@@ -186,7 +187,7 @@ func (h *HashMap) Type() ObjectType { return HASHMAP_OBJ }
 func (h *HashMap) AsString() string {
 	var out bytes.Buffer
 	pairs := []string{}
-	for _, pair := range h.KVPs {
+	for _, pair := range h.MP {
 		pairs = append(pairs, fmt.Sprintf("%s: %s",
 			pair.Key.AsString(), pair.Value.AsString()))
 	}
@@ -197,7 +198,7 @@ func (h *HashMap) AsString() string {
 }
 
 type Chest struct {
-	Items map[String]Object
+	Items map[string]Object
 }
 
 func (t *Chest) Type() ObjectType { return CHEST_OBJ }
@@ -211,6 +212,20 @@ func (t *Chest) AsString() string {
 	}
 	out.WriteString("|")
 	out.WriteString(strings.Join(pairs, ", "))
+	out.WriteString("|")
+	return out.String()
+}
+
+type ChestType struct {
+	Fields []string
+}
+
+func (ct *ChestType) Type() ObjectType { return CHEST_TYPE_OBJ }
+
+func (ct *ChestType) AsString() string {
+	var out bytes.Buffer
+	out.WriteString("chest|")
+	out.WriteString(strings.Join(ct.Fields, ", "))
 	out.WriteString("|")
 	return out.String()
 }


### PR DESCRIPTION
## Summary
- add runtime Chest and ChestType objects
- support chest literals, declarations, instantiation, access, and field assignment in evaluator
- exercise chest features with new tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ae70bdeedc8325b4821a708f44687c