### PR TITLE
Fix chest access parsing and string formatting

### DIFF
--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -657,3 +657,21 @@ inst|foo.
 	evaluated := testEval(input)
 	testIntegerObject(t, evaluated, 10)
 }
+
+func TestChestAsStringQuotesStrings(t *testing.T) {
+	input := `
+chest it|yes|.
+yar b be it|"one"|.
+b.
+`
+	evaluated := testEval(input)
+	chest, ok := evaluated.(*object.Chest)
+	if !ok {
+		t.Fatalf("object not Chest. got=%T", evaluated)
+	}
+	expected := `|yes: "one"|`
+	actual := chest.AsString()
+	if actual != expected {
+		t.Fatalf("chest AsString wrong. expected=%q, got=%q", expected, actual)
+	}
+}

--- a/object/object.go
+++ b/object/object.go
@@ -207,8 +207,11 @@ func (t *Chest) AsString() string {
 	var out bytes.Buffer
 	pairs := []string{}
 	for id, obj := range t.Items {
-		pairs = append(pairs, fmt.Sprintf("%s: %s",
-			id, obj.AsString()))
+		val := obj.AsString()
+		if obj.Type() == STRING_OBJ {
+			val = fmt.Sprintf("\"%s\"", val)
+		}
+		pairs = append(pairs, fmt.Sprintf("%s: %s", id, val))
 	}
 	out.WriteString("|")
 	out.WriteString(strings.Join(pairs, ", "))

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -449,6 +449,7 @@ func isChestAccessTerminator(t token.TokenType) bool {
 	case token.PERIOD, token.BE, token.PLUS, token.MINUS, token.FSLASH,
 		token.STAR, token.MOD, token.EQUAL, token.NOTEQUAL, token.AND,
 		token.OR, token.LESS, token.GREATER, token.LESSEQ, token.GREATEREQ,
+		token.RPAREN, token.RBRACKET, token.RBRACE, token.COMMA,
 		token.EOF:
 		return true
 	default:

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1349,3 +1349,21 @@ func TestChestAccessInInfixExpressionPrecedence(t *testing.T) {
 		t.Fatalf("precedence/String mismatch. expected=%q, got=%q", expected, actual)
 	}
 }
+
+func TestChestAccessAsCallArgument(t *testing.T) {
+	input := "ahoy(myChest|field)."
+	program, p := parseProgramFromInput(input)
+	printErrors(t, p)
+
+	stmt := program.Statements[0].(*ast.ExpressionStatement)
+	call, ok := stmt.Expression.(*ast.CallExpression)
+	if !ok {
+		t.Fatalf("stmt.Expression not *ast.CallExpression, got=%T", stmt.Expression)
+	}
+	if len(call.Arguments) != 1 {
+		t.Fatalf("call.Arguments length wrong. expected=1, got=%d", len(call.Arguments))
+	}
+	if _, ok := call.Arguments[0].(*ast.ChestAccess); !ok {
+		t.Fatalf("argument not *ast.ChestAccess. got=%T", call.Arguments[0])
+	}
+}


### PR DESCRIPTION
## Summary
- quote string values when printing chests
- allow chest field access inside expressions like function calls
- test chest access as call argument and verify chest strings quote values

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b11ee2b8048325ae49259eb3779910