### PR TITLE
Support function calls on chest fields

### DIFF
--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -691,3 +691,16 @@ b.
 		t.Fatalf("chest AsString wrong. expected=%q, got=%q", expected, actual)
 	}
 }
+
+func TestChestFunctionFieldCall(t *testing.T) {
+	input := `
+chest myChest|foo|.
+yar funco be f():
+    gives 5.
+.
+yar inst be myChest|funco|.
+inst|foo().
+`
+	evaluated := testEval(input)
+	testIntegerObject(t, evaluated, 5)
+}

--- a/examples/chest.pir
+++ b/examples/chest.pir
@@ -1,14 +1,21 @@
 $ Define a chest.
 chest myChest|foo, bar|.
 
+$ A function to store in the chest.
+yar funco be f():
+    gives "returns".
+.
+
 $ Instantiate it with positional or named args to set the chest's items.
-yar instance be myChest|"fooVal", "barVal"|. 
+yar instance be myChest|"fooVal", funco|.
 yar anotherInstance be myChest|bar: "anotherBarVal", 
                                foo: "anotherFooVal"|.
 
 ahoy(instance).
 
 $ Access props with |
-anotherInstance|foo be intance|foo.
+anotherInstance|foo be instance|foo.
 
 ahoy(anotherInstance).
+
+ahoy(instance|bar()).

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -426,7 +426,7 @@ func (p *Parser) parseChestAccessOrInstantiation(left ast.Expression) ast.Expres
 	if p.peekToken.Is(token.IDENT) {
 		t2 := p.peekToken2.Type
 		t3 := p.peekToken3.Type
-		if isChestAccessTerminator(t2) || (p.peekToken2.Is(token.PIPE) && t3 == token.IDENT) {
+		if isChestAccessTerminator(t2) || t2 == token.LPAREN || t2 == token.LBRACKET || (p.peekToken2.Is(token.PIPE) && t3 == token.IDENT) {
 			p.advanceTokens()
 			fieldTok := p.curToken
 			ident := &ast.Identifier{Token: fieldTok, Value: fieldTok.Literal}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1408,3 +1408,25 @@ func TestChestAccessAsCallArgument(t *testing.T) {
 		t.Fatalf("argument not *ast.ChestAccess. got=%T", call.Arguments[0])
 	}
 }
+
+func TestChestAccessFollowedByCall(t *testing.T) {
+	input := "inst|foo()."
+	program, p := parseProgramFromInput(input)
+	printErrors(t, p)
+
+	stmt := program.Statements[0].(*ast.ExpressionStatement)
+	call, ok := stmt.Expression.(*ast.CallExpression)
+	if !ok {
+		t.Fatalf("exp not *ast.CallExpression, got=%T", stmt.Expression)
+	}
+	chestAccess, ok := call.Function.(*ast.ChestAccess)
+	if !ok {
+		t.Fatalf("call.Function not *ast.ChestAccess. got=%T", call.Function)
+	}
+	if !testIdentifier(t, chestAccess.Left, "inst") {
+		return
+	}
+	if !testIdentifier(t, chestAccess.Field, "foo") {
+		return
+	}
+}


### PR DESCRIPTION
## Summary
- parse `inst|field()` as chest access before the call
- cover chest field calls with new parser and evaluator tests
- refresh `examples/chest.pir` to showcase chest functions

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b127fb148c8325a552cb61f1f1dd4b